### PR TITLE
カメラが応答なしの場合に、アラームとプライバシーモード設定をしようとした際の例外を処理する。

### DIFF
--- a/src/cameraAccessory.ts
+++ b/src/cameraAccessory.ts
@@ -97,7 +97,15 @@ export class CameraAccessory {
       })
       .onSet((status) => {
         this.log.debug(`Setting alarm to ${status ? "on" : "off"}`);
-        this.camera.setAlertConfig(Boolean(status));
+        this.camera.setAlertConfig(Boolean(status))
+          .catch(err => {
+            this.log.error(
+              `[${this.config.name}]`,
+              "Error at 'setAlertConfig'.",
+              err
+            );
+            this.cameraStatus = undefined; // Home.app shows 'No Response'
+          });
       });
   }
 
@@ -120,7 +128,15 @@ export class CameraAccessory {
       })
       .onSet((status) => {
         this.log.debug(`Setting privacy to ${status ? "on" : "off"}`);
-        this.camera.setLensMaskConfig(!status);
+        this.camera.setLensMaskConfig(!status)
+          .catch(err => {
+            this.log.error(
+              `[${this.config.name}]`,
+              "Error at 'setLensMaskConfig'.",
+              err
+            );
+            this.cameraStatus = undefined; // Home.app shows 'No Response'
+          });
       });
   }
 


### PR DESCRIPTION
UIからはアクセサリの操作はブロックされるが、シーンやオートメーションにて発生しうる。
